### PR TITLE
Loosen jsx-bind rule to allow functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,11 @@ export default {
 		'react/no-deprecated': 2,
 		'react/react-in-jsx-scope': 0, // handled this automatically
 		'react/display-name': [1, { ignoreTranspilerName: false }],
-		'react/jsx-no-bind': [1, { ignoreRefs: true }],
+		'react/jsx-no-bind': [1, {
+			ignoreRefs: true,
+			allowFunctions: true,
+			allowArrowFunctions: true
+		}],
 		'react/jsx-no-comment-textnodes': 2,
 		'react/jsx-no-duplicate-props': 2,
 		'react/jsx-no-target-blank': 2,


### PR DESCRIPTION
This PR loosens the rule regarding inline functions for event handlers. Personally I've found that the difference is hardly measurable on any devices I own. Plus in Preact's case we just swap an object pointer during diff.

```jsx
<Foo onClick={() => alert("1337")} />
<Foo onClick={function () { alert("1337") }} />
```