### PR TITLE
Fix eslint extend not finding preact config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "module": "dist/eslint-config-preact.module.js",
   "exports": {
     ".": {
-      "import": "dist/eslint-config-preact.module.js",
-      "require": "dist/eslint-config-preact.js"
+      "import": "./dist/eslint-config-preact.module.js",
+      "require": "./dist/eslint-config-preact.js"
     }
   },
   "files": [


### PR DESCRIPTION
Node conditional exports _must_ be specified as relative paths contrary
to "main" and "module" fields. Otherwise newer node versions >= 13.8.0 will throw an error during module resolution.

Fixes #3 .