### PR TITLE
Allow current ESLint (7.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",
-    "eslint": "^6.8.0",
+    "eslint": "^7.9.0",
     "jest": "^25.1.0",
     "microbundle": "^0.12.0-next.8"
   },
   "peerDependencies": {
-    "eslint": "6.x"
+    "eslint": "6.x || 7.x"
   }
 }


### PR DESCRIPTION
Since no changes was required to allow 7.x, 6.x is still enabled in peer deps.