### PR TITLE
fix eslint-plugin-react-hook version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-compat": "^3.5.1",
     "eslint-plugin-jest": "^23.7.0",
     "eslint-plugin-react": "^7.0.0",
-    "eslint-plugin-react-hooks": "^2.4.0 || ^3.0.0 || ^4.0.0"
+    "eslint-plugin-react-hooks": "^4.2.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-compat": "^3.5.1",
     "eslint-plugin-jest": "^23.7.0",
     "eslint-plugin-react": "^7.0.0",
-    "eslint-plugin-react-hooks": "^2.4.0"
+    "eslint-plugin-react-hooks": "^2.4.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "@types/jest": "^25.1.2",


### PR DESCRIPTION
fix `eslint-plugin-react-hook` version to work with eslint 7.x

> ERROR eslint-config-preact: eslint-plugin-react-hooks@2.5.1 requires a peer of eslint@^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 but version 7.12.1 was installed