### PR TITLE
Add react/jsx-key

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ export default {
 		'react/jsx-tag-spacing': [2, { beforeSelfClosing: 'always' }],
 		'react/jsx-uses-react': 2, // debatable
 		'react/jsx-uses-vars': 2,
+		'react/jsx-key': [2, { checkFragmentShorthand: true },
 		'react/self-closing-comp': 2,
 		'react/prefer-es6-class': 2,
 		'react/prefer-stateless-function': 1,


### PR DESCRIPTION
This PR adds the `react/jsx-key` rule to lint for missing keys on components created in a loop. It wasn't apparent from the preactjs.com docs if this is required for components that are not fragments but I figured this would be useful.