### PR TITLE
refactor: Replacing babel-eslint with @babel/eslint-parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,13 +10,15 @@ export default {
 		ecmaFeatures: {
 			modules: true,
 			impliedStrict: true,
-			experimentalObjectRestSpread: true,
-			experimentalDecorators: true,
 			jsx: true
 		},
 		requireConfigFile: false,
 		babelOptions: {
-			plugins: ['@babel/plugin-syntax-jsx', '@babel/plugin-syntax-class-properties']
+			plugins: [
+				'@babel/plugin-syntax-class-properties',
+				['@babel/plugin-syntax-decorators', { decoratorsBeforeExport: false }],
+				'@babel/plugin-syntax-jsx'
+			]
 		}
 	},
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 export default {
 	// TODO: this is really only required for class property initializer methods, which are seeing declining usage.
 	// At some point, we should un-ship the custom parser and let ESLint use esprima.
-	parser: require.resolve('babel-eslint'),
+	parser: require.resolve('@babel/eslint-parser'),
 
 	// Currently ignored due to the custom parser.
 	parserOptions: {
@@ -13,6 +13,10 @@ export default {
 			experimentalObjectRestSpread: true,
 			experimentalDecorators: true,
 			jsx: true
+		},
+		requireConfigFile: false,
+		babelOptions: {
+			plugins: ['@babel/plugin-syntax-jsx', '@babel/plugin-syntax-class-properties']
 		}
 	},
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,10 @@
     ]
   },
   "dependencies": {
-    "babel-eslint": "^10.0.1",
+    "@babel/core": "^7.13.16",
+    "@babel/eslint-parser": "^7.13.14",
+    "@babel/plugin-syntax-jsx": "^7.12.13",
+    "@babel/plugin-syntax-class-properties": "^7.12.13",
     "eslint-plugin-compat": "^3.5.1",
     "eslint-plugin-jest": "^23.7.0",
     "eslint-plugin-react": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,9 @@
   "dependencies": {
     "@babel/core": "^7.13.16",
     "@babel/eslint-parser": "^7.13.14",
-    "@babel/plugin-syntax-jsx": "^7.12.13",
     "@babel/plugin-syntax-class-properties": "^7.12.13",
+    "@babel/plugin-syntax-decorators": "^7.12.13",
+    "@babel/plugin-syntax-jsx": "^7.12.13",
     "eslint-plugin-compat": "^3.5.1",
     "eslint-plugin-jest": "^23.7.0",
     "eslint-plugin-react": "^7.0.0",


### PR DESCRIPTION
`babel-eslint` has been deprecated in favor of `@babel/eslint-parser`. Probably not a big deal at the moment, but I figured I'd fix it now that I've noticed.