### PR TITLE
Set plugin-syntax-decorators to useLegacy = true

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ export default {
 		babelOptions: {
 			plugins: [
 				'@babel/plugin-syntax-class-properties',
-				['@babel/plugin-syntax-decorators', { useLegacy: true }],
 				'@babel/plugin-syntax-jsx'
 			]
 		}

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ export default {
 		babelOptions: {
 			plugins: [
 				'@babel/plugin-syntax-class-properties',
-				['@babel/plugin-syntax-decorators', { decoratorsBeforeExport: false }],
+				['@babel/plugin-syntax-decorators', { useLegacy: true }],
 				'@babel/plugin-syntax-jsx'
 			]
 		}


### PR DESCRIPTION
Remove `@plugin-syntax-decorators` plugin to fix #21