### PR TITLE
test: ignore suggestions in snapshots

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,9 @@
 name: Node CI
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   build:

--- a/test/__snapshots__/index.test.mjs.snap
+++ b/test/__snapshots__/index.test.mjs.snap
@@ -19,6 +19,7 @@ exports[`config: eslint.config.test.cjs > Fixture: component > invalid > fixture
         "nodeType": "ClassDeclaration",
         "ruleId": "react/prefer-stateless-function",
         "severity": 1,
+        "suggestions": undefined,
       },
       {
         "column": 2,
@@ -30,19 +31,7 @@ exports[`config: eslint.config.test.cjs > Fixture: component > invalid > fixture
         "nodeType": "MethodDefinition",
         "ruleId": "no-useless-constructor",
         "severity": 1,
-        "suggestions": [
-          {
-            "desc": "Remove the constructor.",
-            "fix": {
-              "range": [
-                73,
-                102,
-              ],
-              "text": "",
-            },
-            "messageId": "removeConstructor",
-          },
-        ],
+        "suggestions": undefined,
       },
     ],
     "source": "import { Component } from 'preact';
@@ -94,6 +83,7 @@ exports[`config: eslint.config.test.cjs > Fixture: hooks > invalid > fixtures/ho
         "nodeType": "Identifier",
         "ruleId": "react-hooks/exhaustive-deps",
         "severity": 1,
+        "suggestions": undefined,
       },
       {
         "column": 5,
@@ -104,18 +94,7 @@ exports[`config: eslint.config.test.cjs > Fixture: hooks > invalid > fixtures/ho
         "nodeType": "ArrayExpression",
         "ruleId": "react-hooks/exhaustive-deps",
         "severity": 1,
-        "suggestions": [
-          {
-            "desc": "Update the dependencies array to be: [value]",
-            "fix": {
-              "range": [
-                236,
-                238,
-              ],
-              "text": "[value]",
-            },
-          },
-        ],
+        "suggestions": undefined,
       },
     ],
     "source": "import { useState, useCallback, useEffect } from 'preact/hooks';
@@ -173,6 +152,7 @@ exports[`config: eslint.config.test.mjs > Fixture: component > invalid > fixture
         "nodeType": "ClassDeclaration",
         "ruleId": "react/prefer-stateless-function",
         "severity": 1,
+        "suggestions": undefined,
       },
       {
         "column": 2,
@@ -184,19 +164,7 @@ exports[`config: eslint.config.test.mjs > Fixture: component > invalid > fixture
         "nodeType": "MethodDefinition",
         "ruleId": "no-useless-constructor",
         "severity": 1,
-        "suggestions": [
-          {
-            "desc": "Remove the constructor.",
-            "fix": {
-              "range": [
-                73,
-                102,
-              ],
-              "text": "",
-            },
-            "messageId": "removeConstructor",
-          },
-        ],
+        "suggestions": undefined,
       },
     ],
     "source": "import { Component } from 'preact';
@@ -248,6 +216,7 @@ exports[`config: eslint.config.test.mjs > Fixture: hooks > invalid > fixtures/ho
         "nodeType": "Identifier",
         "ruleId": "react-hooks/exhaustive-deps",
         "severity": 1,
+        "suggestions": undefined,
       },
       {
         "column": 5,
@@ -258,18 +227,7 @@ exports[`config: eslint.config.test.mjs > Fixture: hooks > invalid > fixtures/ho
         "nodeType": "ArrayExpression",
         "ruleId": "react-hooks/exhaustive-deps",
         "severity": 1,
-        "suggestions": [
-          {
-            "desc": "Update the dependencies array to be: [value]",
-            "fix": {
-              "range": [
-                236,
-                238,
-              ],
-              "text": "[value]",
-            },
-          },
-        ],
+        "suggestions": undefined,
       },
     ],
     "source": "import { useState, useCallback, useEffect } from 'preact/hooks';

--- a/test/index.test.mjs
+++ b/test/index.test.mjs
@@ -19,6 +19,10 @@ async function lint (file, cli) {
 	return {
 		report: report.map((r) => ({
 			...r,
+			messages: r.messages.map((m) => ({
+				...m,
+				suggestions: undefined, // since ESLint 8 doesn't return these
+			})),
 			filePath: '<filePath>'
 		})),
 		...lintResults[0],


### PR DESCRIPTION
ESLint 8 doesn't seem to return these, so we can just ignore them for
now I think. This will allow us to run tests against 8.x and 9.x.

last one i think?

we can probably release it if CI passes 🤔 or at least a pre-release